### PR TITLE
Update Http.pm, add full_response mode

### DIFF
--- a/app/lib/Core/Transport/Http.pm
+++ b/app/lib/Core/Transport/Http.pm
@@ -190,7 +190,16 @@ sub _http {
         %args,
     );
 
-    return $response->json_content || $response->decoded_content;
+    if ($args{full_response}) {
+        return {
+            http_headers     => { $response->headers->flatten },
+            http_code        => $response->code,
+            http_status_line => $response->status_line,
+            body             => $response->json_content || $response->decoded_content,
+        };
+    } else {
+        return $response->json_content || $response->decoded_content;
+    }
 }
 
 sub get { return shift->_http( 'get', @_ ) }


### PR DESCRIPTION
Добавил для использования в шаблонах вывод кода ответа, строки статуса ответа, и заголовков.  Если в параметрах метода указать **'full_response',1** -  ```{{ result = http.get( URL, 'headers',headers, 'full_response',1 ) }}```, метод вернет полное содержимое в виде: 
```
 {
   "body":[
      {
         "dns_servers":[
               "1.1.1.1",
               "1.0.0.1"
            ]
      }
   ],
   "http_code":"200",
   "http_headers":{
      "Content-Type":"application/json; charset=utf-8",
      "Date":"Wed, 05 Nov 2025 08:52:26 GMT"
   },
   "http_status_line":"200 OK"
}
```
Таким образом прежний код продолжит работать как раньше, а если нужен полный ответ, то необходимо добавить этот параметр.