### PR TITLE
Эндпоинт который возвращает промокоды, созданные текущим пользователем

### DIFF
--- a/app/lib/Core/Promo.pm
+++ b/app/lib/Core/Promo.pm
@@ -166,29 +166,6 @@ sub api_get {
     my @list = $self->list(
         where => {
             user_id => $self->user->id,
-            used_by => $self->user->id,
-        },
-    );
-
-    my @data;
-    foreach my $item (@list) {
-        if (ref($item) eq 'HASH') {
-            push @data, {
-                promo_code => $item->{id},
-                used_date => $item->{used},
-            };
-        }
-    }
-
-    return @data;
-}
-
-sub api_created {
-    my $self = shift;
-
-    my @list = $self->list(
-        where => {
-            user_id => $self->user->id,
         },
         order => [
             'id'      => 'asc',
@@ -207,16 +184,18 @@ sub api_created {
 
         my $settings = $item->{settings} || {};
 
+        # Пропускаем записи использования reusable-промокодов (не корневые)
         next if $item->{used} && $settings->{reusable};
 
         push @data, {
-            promo_code  => $code,
-            template_id => $item->{template_id},
-            created     => $item->{created},
-            expire      => $item->{expire},
-            reusable    => $settings->{reusable} ? 1 : 0,
-            status      => exists $settings->{status} ? $settings->{status} : 1,
-            used        => $settings->{reusable} ? 0 : ($item->{used} ? 1 : 0),
+            promo_code => $code,
+            created    => $item->{created},
+            expire     => $item->{expire},
+            reusable   => $settings->{reusable} ? 1 : 0,
+            status     => exists $settings->{status} ? $settings->{status} : 1,
+            used       => $settings->{reusable} ? 0 : ($item->{used} ? 1 : 0),
+            used_date  => $item->{used},
+            used_by    => $item->{used_by},
         };
     }
 

--- a/app/public_html/shm/v1.cgi
+++ b/app/public_html/shm/v1.cgi
@@ -602,7 +602,7 @@ state $routes //= {
         controller => 'Promo',
         method => 'api_get',
         swagger => {
-            summary => 'Список использованных промокодов',
+            summary => 'Список промокодов пользователя',
             responses => {
                 '200' => {
                     content => {
@@ -611,39 +611,6 @@ state $routes //= {
                                 type => 'object',
                                 properties => {
                                     promo_code => {
-                                        type => 'string'
-                                    },
-                                    used_date => {
-                                        type => 'string',
-                                        format => 'date',
-                                    },
-                                },
-                            },
-                        },
-                    },
-                },
-            },
-        },
-    },
-},
-'/promo/created' => {
-    swagger => { tags => 'Промокоды' },
-    GET => {
-        controller => 'Promo',
-        method => 'api_created',
-        swagger => {
-            summary => 'Список промокодов, созданных пользователем',
-            responses => {
-                '200' => {
-                    content => {
-                        'application/json' => {
-                            schema => {
-                                type => 'object',
-                                properties => {
-                                    promo_code => {
-                                        type => 'string',
-                                    },
-                                    template_id => {
                                         type => 'string',
                                     },
                                     created => {
@@ -666,6 +633,15 @@ state $routes //= {
                                         type => 'integer',
                                         enum => [0, 1],
                                         description => 'Использован ли промокод (только для одноразовых, для reusable всегда 0)',
+                                    },
+                                    used_date => {
+                                        type => 'string',
+                                        format => 'date-time',
+                                        description => 'Дата использования промокода',
+                                    },
+                                    used_by => {
+                                        type => 'integer',
+                                        description => 'ID пользователя, использовавшего промокод',
                                     },
                                 },
                             },


### PR DESCRIPTION
Сейчас в клиентском API нет способа получить список промокодов, **которые пользователь сам создал**. Так как на промокоды можно подвязать различные функции получение такого списка в клиентом пригодилось бы.

Впервые делаю PR. Может что-то упустил. Использовал ИИ для изменения. Тесты провел - вроде все ок.

## Summary

- Добавлен эндпоинт `/shm/v1/promo/created`, который возвращает промокоды, **созданные текущим пользователем**.

## Changes

### 1. Новый метод `Promo::api_created`

Файл `app/lib/Core/Promo.pm`


### 2. Новый эндпоинт `/shm/v1/promo/created` + Swagger

Файл `app/public_html/shm/v1.cgi`:


## Testing

- **Интеграционный тест промокодов**:

  ```bash
  docker compose exec core prove -v /app/t/integration/promo/promo.t
  ```

  Результат:

  - `Check promo` — OK
  - `Check reusable promo` — OK
  - `Result: PASS`

- **Ручная проверка нового эндпоинта**:
  - создание test-пользователя;
  - генерация трёх промокодов на этого пользователя;
  - запрос `/shm/v1/promo/created` возвращает именно эти три промокода, с ожидаемыми полями и без данных других пользователей.

Пример ответа:

```json
{
  "TZ": "Europe/Moscow",
  "data": [
    {
      "created": "2026-03-03 23:37:56",
      "expire": null,
      "promo_code": "CID2_M8EBAFXRN1",
      "reusable": 0,
      "status": 1,
      "template_id": "test_promo_for_cid2",
      "used": 0
    },
    {
      "created": "2026-03-03 23:37:56",
      "expire": null,
      "promo_code": "CID2_N3RARNNX6P",
      "reusable": 0,
      "status": 1,
      "template_id": "test_promo_for_cid2",
      "used": 0
    },
    {
      "created": "2026-03-03 23:37:56",
      "expire": null,
      "promo_code": "CID2_TKBT1KTTZX",
      "reusable": 0,
      "status": 1,
      "template_id": "test_promo_for_cid2",
      "used": 0
    }
  ],
  "items": 3,
  "limit": 25,
  "offset": 0,
  "status": 200,
  "version": "0.0.1-"
}
```
