### PR TITLE
fix: use variable-based fastcgi_pass to enable dynamic DNS resolution

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -3,108 +3,103 @@ worker_processes auto;
 pid /run/nginx.pid;
 
 events {
-    worker_connections 1024;
+        worker_connections 1024;
 }
 
 http {
-    include /etc/nginx/mime.types;
-    default_type application/octet-stream;
+        include /etc/nginx/mime.types;
+        default_type application/octet-stream;
 
-    set_real_ip_from 172.16.0.0/12;
-    set_real_ip_from 192.168.0.0/16;
-    set_real_ip_from 10.0.0.0/8;
-    real_ip_header X-Forwarded-For;
-    real_ip_recursive on;
+        set_real_ip_from 172.16.0.0/12;
+        set_real_ip_from 192.168.0.0/16;
+        set_real_ip_from 10.0.0.0/8;
+        real_ip_header X-Forwarded-For;
+        real_ip_recursive on;
 
-    geo $limit_ip {
-        default $binary_remote_addr;
-        127.0.0.0/8 "";
-        10.0.0.0/8 "";
-        172.16.0.0/12 "";
-        192.168.0.0/16 "";
+        geo $limit_ip {
+                default $binary_remote_addr;
+                127.0.0.0/8 "";
+                10.0.0.0/8 "";
+                172.16.0.0/12 "";
+                192.168.0.0/16 "";
     }
 
-    limit_req_zone $limit_ip zone=perip:10m rate=1r/s;
+        ##limit_req_zone $limit_ip zone=perip:10m rate=1r/s;
 
-    limit_req_status 429;
-    limit_req_log_level warn;
+        ##limit_req_status 429;
+        ##limit_req_log_level warn;
 
-    log_format json_combined escape=json '{'
-        '"time": "$time_iso8601",'
-        '"remote_addr": "$remote_addr",'
-        '"real_ip": "$realip_remote_addr",'
-        '"method": "$request_method",'
-        '"uri": "$request_uri",'
-        '"status": $status,'
-        '"body_bytes_sent": $body_bytes_sent,'
-        '"request_time": $request_time,'
-        '"user_agent": "$http_user_agent",'
-        '"forwarded_for": "$http_x_forwarded_for"'
-    '}';
+        log_format json_combined escape=json '{'
+                '"time": "$time_iso8601",'
+                '"remote_addr": "$remote_addr",'
+                '"real_ip": "$realip_remote_addr",'
+                '"method": "$request_method",'
+                '"uri": "$request_uri",'
+                '"status": $status,'
+                '"body_bytes_sent": $body_bytes_sent,'
+                '"request_time": $request_time,'
+                '"user_agent": "$http_user_agent",'
+                '"forwarded_for": "$http_x_forwarded_for"'
+            '}';
 
-    access_log /var/log/nginx/access.log json_combined;
-    error_log /var/log/nginx/error.log error;
+        access_log /var/log/nginx/access.log json_combined;
+        error_log /var/log/nginx/error.log error;
 
-    sendfile on;
-    keepalive_timeout 65;
+        sendfile on;
+        keepalive_timeout 65;
 
-    # FastCGI upstream
-    upstream fastcgi_backend {
-        server core:9082;
-    }
+        server {
+                listen 80 default_server;
+                listen [::]:80 default_server;
+                server_name _;
+                root /app/public_html/;
 
-    server {
-        listen 80 default_server;
-        listen [::]:80 default_server;
-        server_name _;
-        root /app/public_html/;
+                charset utf8;
+                index index.html;
 
-        charset utf8;
-        index index.html;
+                ##limit_req zone=perip burst=5 nodelay;
 
-        limit_req zone=perip burst=5 nodelay;
+                error_page 403 /403.html;
+                error_page 404 /404.html;
+                error_page 429 @rate_limit_error;
 
-        error_page 403 /403.html;
-        error_page 404 /404.html;
-        error_page 429 @rate_limit_error;
+                resolver 127.0.0.11 valid=3s ipv6=off;
+                set $fastcgi_backend "core:9082";
 
-        resolver 127.0.0.11 valid=3s ipv6=off;
-
-        location = /shm/healthcheck.cgi {
-            access_log off;
-            include fastcgi_params;
-            fastcgi_param PERL5LIB "/app/lib:/app/conf";
-            fastcgi_param TRUSTED_IPS "TRUSTED_IPS_PLACEHOLDER";
-            fastcgi_read_timeout 300s;
-            fastcgi_pass fastcgi_backend;
+                location = /shm/healthcheck.cgi {
+                        access_log off;
+                        include fastcgi_params;
+                        fastcgi_param PERL5LIB "/app/lib:/app/conf";
+                        fastcgi_param TRUSTED_IPS "";
+                        fastcgi_read_timeout 300s;
+                        fastcgi_pass $fastcgi_backend;
         }
 
-        location ~ \.cgi$ {
-            include fastcgi_params;
-            fastcgi_param PERL5LIB "/app/lib:/app/conf";
-            fastcgi_param TRUSTED_IPS "TRUSTED_IPS_PLACEHOLDER";
-            fastcgi_read_timeout 300s;
-            fastcgi_pass fastcgi_backend;
+                location ~ \.cgi$ {
+                        include fastcgi_params;
+                        fastcgi_param PERL5LIB "/app/lib:/app/conf";
+                        fastcgi_param TRUSTED_IPS "";
+                        fastcgi_read_timeout 300s;
+                        fastcgi_pass $fastcgi_backend;
         }
 
-        location / {
-            # Try static files first
-            try_files $uri @fastcgi;
+                location / {
+                        # Try static files first
+                        try_files $uri @fastcgi;
         }
 
-        location @fastcgi {
-            include fastcgi_params;
-            fastcgi_param PERL5LIB "/app/lib:/app/conf";
-            fastcgi_param TRUSTED_IPS "TRUSTED_IPS_PLACEHOLDER";
-            fastcgi_read_timeout 300s;
-            fastcgi_pass fastcgi_backend;
+                location @fastcgi {
+                        include fastcgi_params;
+                        fastcgi_param PERL5LIB "/app/lib:/app/conf";
+                        fastcgi_param TRUSTED_IPS "";
+                        fastcgi_read_timeout 300s;
+                        fastcgi_pass $fastcgi_backend;
         }
 
-        location @rate_limit_error {
-            internal;
-            default_type application/json;
-            return 429 '{"status": 429, "error": "Too Many Requests"}';
+                location @rate_limit_error {
+                        internal;
+                        default_type application/json;
+                        return 429 '{"status": 429, "error": "Too Many Requests"}';
         }
     }
 }
-

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -3,103 +3,103 @@ worker_processes auto;
 pid /run/nginx.pid;
 
 events {
-        worker_connections 1024;
+    worker_connections 1024;
 }
 
 http {
-        include /etc/nginx/mime.types;
-        default_type application/octet-stream;
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
 
-        set_real_ip_from 172.16.0.0/12;
-        set_real_ip_from 192.168.0.0/16;
-        set_real_ip_from 10.0.0.0/8;
-        real_ip_header X-Forwarded-For;
-        real_ip_recursive on;
+    set_real_ip_from 172.16.0.0/12;
+    set_real_ip_from 192.168.0.0/16;
+    set_real_ip_from 10.0.0.0/8;
+    real_ip_header X-Forwarded-For;
+    real_ip_recursive on;
 
-        geo $limit_ip {
-                default $binary_remote_addr;
-                127.0.0.0/8 "";
-                10.0.0.0/8 "";
-                172.16.0.0/12 "";
-                192.168.0.0/16 "";
+    geo $limit_ip {
+        default $binary_remote_addr;
+        127.0.0.0/8 "";
+        10.0.0.0/8 "";
+        172.16.0.0/12 "";
+        192.168.0.0/16 "";
     }
 
-        ##limit_req_zone $limit_ip zone=perip:10m rate=1r/s;
+    limit_req_zone $limit_ip zone=perip:10m rate=1r/s;
 
-        ##limit_req_status 429;
-        ##limit_req_log_level warn;
+    limit_req_status 429;
+    limit_req_log_level warn;
 
-        log_format json_combined escape=json '{'
-                '"time": "$time_iso8601",'
-                '"remote_addr": "$remote_addr",'
-                '"real_ip": "$realip_remote_addr",'
-                '"method": "$request_method",'
-                '"uri": "$request_uri",'
-                '"status": $status,'
-                '"body_bytes_sent": $body_bytes_sent,'
-                '"request_time": $request_time,'
-                '"user_agent": "$http_user_agent",'
-                '"forwarded_for": "$http_x_forwarded_for"'
-            '}';
+    log_format json_combined escape=json '{'
+        '"time": "$time_iso8601",'
+        '"remote_addr": "$remote_addr",'
+        '"real_ip": "$realip_remote_addr",'
+        '"method": "$request_method",'
+        '"uri": "$request_uri",'
+        '"status": $status,'
+        '"body_bytes_sent": $body_bytes_sent,'
+        '"request_time": $request_time,'
+        '"user_agent": "$http_user_agent",'
+        '"forwarded_for": "$http_x_forwarded_for"'
+    '}';
 
-        access_log /var/log/nginx/access.log json_combined;
-        error_log /var/log/nginx/error.log error;
+    access_log /var/log/nginx/access.log json_combined;
+    error_log /var/log/nginx/error.log error;
 
-        sendfile on;
-        keepalive_timeout 65;
+    sendfile on;
+    keepalive_timeout 65;
 
-        server {
-                listen 80 default_server;
-                listen [::]:80 default_server;
-                server_name _;
-                root /app/public_html/;
+    server {
+        listen 80 default_server;
+        listen [::]:80 default_server;
+        server_name _;
+        root /app/public_html/;
 
-                charset utf8;
-                index index.html;
+        charset utf8;
+        index index.html;
 
-                ##limit_req zone=perip burst=5 nodelay;
+        limit_req zone=perip burst=5 nodelay;
 
-                error_page 403 /403.html;
-                error_page 404 /404.html;
-                error_page 429 @rate_limit_error;
+        error_page 403 /403.html;
+        error_page 404 /404.html;
+        error_page 429 @rate_limit_error;
 
-                resolver 127.0.0.11 valid=3s ipv6=off;
-                set $fastcgi_backend "core:9082";
+        resolver 127.0.0.11 valid=3s ipv6=off;
+        set $fastcgi_backend "core:9082";
 
-                location = /shm/healthcheck.cgi {
-                        access_log off;
-                        include fastcgi_params;
-                        fastcgi_param PERL5LIB "/app/lib:/app/conf";
-                        fastcgi_param TRUSTED_IPS "";
-                        fastcgi_read_timeout 300s;
-                        fastcgi_pass $fastcgi_backend;
+        location = /shm/healthcheck.cgi {
+            access_log off;
+            include fastcgi_params;
+            fastcgi_param PERL5LIB "/app/lib:/app/conf";
+            fastcgi_param TRUSTED_IPS "TRUSTED_IPS_PLACEHOLDER";
+            fastcgi_read_timeout 300s;
+            fastcgi_pass $fastcgi_backend;
         }
 
-                location ~ \.cgi$ {
-                        include fastcgi_params;
-                        fastcgi_param PERL5LIB "/app/lib:/app/conf";
-                        fastcgi_param TRUSTED_IPS "";
-                        fastcgi_read_timeout 300s;
-                        fastcgi_pass $fastcgi_backend;
+        location ~ \.cgi$ {
+            include fastcgi_params;
+            fastcgi_param PERL5LIB "/app/lib:/app/conf";
+            fastcgi_param TRUSTED_IPS "TRUSTED_IPS_PLACEHOLDER";
+            fastcgi_read_timeout 300s;
+            fastcgi_pass $fastcgi_backend;
         }
 
-                location / {
-                        # Try static files first
-                        try_files $uri @fastcgi;
+        location / {
+            # Try static files first
+            try_files $uri @fastcgi;
         }
 
-                location @fastcgi {
-                        include fastcgi_params;
-                        fastcgi_param PERL5LIB "/app/lib:/app/conf";
-                        fastcgi_param TRUSTED_IPS "";
-                        fastcgi_read_timeout 300s;
-                        fastcgi_pass $fastcgi_backend;
+        location @fastcgi {
+            include fastcgi_params;
+            fastcgi_param PERL5LIB "/app/lib:/app/conf";
+            fastcgi_param TRUSTED_IPS "TRUSTED_IPS_PLACEHOLDER";
+            fastcgi_read_timeout 300s;
+            fastcgi_pass $fastcgi_backend;
         }
 
-                location @rate_limit_error {
-                        internal;
-                        default_type application/json;
-                        return 429 '{"status": 429, "error": "Too Many Requests"}';
+        location @rate_limit_error {
+            internal;
+            default_type application/json;
+            return 429 '{"status": 429, "error": "Too Many Requests"}';
         }
     }
 }


### PR DESCRIPTION
Блок `upstream` резолвит DNS один раз при старте nginx. Директива `resolver` **не действует** на `upstream` блоки — она работает только когда хост указан через переменную в `proxy_pass` / `fastcgi_pass`.

В Docker, если контейнер `core` перезапускается и получает новый IP, nginx продолжает слать запросы на старый (устаревший) IP → 502.

Этот коммит:
- Убирает блок `upstream fastcgi_backend`
- - Добавляет `set $fastcgi_backend "core:9082"` в блок `server`
- - Меняет все `fastcgi_pass` на использование переменной `$fastcgi_backend`
Теперь существующий `resolver 127.0.0.11 valid=3s` реально начинает работать и пере-резолвит DNS каждые 3 секунды.

---

**Примечание:** Аналогичная проблема есть в образе `shm-admin`. В шаблоне nginx (`/etc/nginx/nginx.conf.template`) используется статический хост в `proxy_pass http://shm.local/shm;` — `resolver` там тоже не работает без переменной. Если `shm-api` перезапустится и получит новый IP, `shm-admin` тоже начнёт возвращать 502.

Предлагаемый фикс для шаблона `shm-admin`:
```nginx
resolver 127.0.0.11 valid=3s ipv6=off;
set $shm_api_backend "http://shm.local";
...
proxy_pass $shm_api_backend;
```
Важно: при использовании переменной в `proxy_pass` nginx не переписывает URI, поэтому суффикс `/shm` нужно убрать — полный оригинальный URI запроса (например `/shm/v1/admin/...`) передаётся как есть.