### PR TITLE
Telegram: не повторять отправку при ошибке "chat not found"

### DIFF
--- a/app/lib/Core/Transport/Telegram.pm
+++ b/app/lib/Core/Transport/Telegram.pm
@@ -135,6 +135,7 @@ sub profile {
     my $config = $self->config;
 
     $self->{profile} = $name;
+    delete $self->{user_tg_settings}; # профиль изменился — сбрасываем кэш настроек
 
     if ( my $profile = $config->{ $name } ) {
         $self->{token} = $profile->{token};
@@ -280,6 +281,11 @@ sub send {
 
         if ( $self->user_tg_settings->{status} eq 'kicked' || $self->user_tg_settings->{status} eq 'left' ) {
             push @ret, { msg => "Пользователь заблокировал Telegram bot", profile => $profile };
+            next;
+        }
+
+        if ( $self->user_tg_settings->{status} eq 'chat_not_found' ) {
+            push @ret, { msg => "Чат с ботом не найден: пользователь ещё не запустил бота", profile => $profile };
             next;
         }
 
@@ -519,20 +525,39 @@ sub http {
     logger->dump('Answer from TG API', $response->decoded_content );
 
     unless ( $response->is_success ) {
-        my $message = $response->decoded_content;
-        logger->error( $message );
-
-        if ( $response->code == 403 ) {
-            $self->user->set_settings({
-                telegram => {
-                    $self->{profile} => {
-                        status => 'kicked',
-                    },
-                }
-            });
-        }
+        logger->error( $response->decoded_content );
+        $self->set_profile_status_by_error( $response );
     }
     return $response;
+}
+
+# Помечаем профиль пользователя по ошибке Telegram API,
+# чтобы не отправлять сообщения в заведомо недоступный чат
+sub set_profile_status_by_error {
+    my $self = shift;
+    my $response = shift;
+
+    my $status;
+    if ( $response->code == 403 ) {
+        # пользователь заблокировал бота
+        $status = 'kicked';
+    } elsif ( $response->code == 400 ) {
+        my $error = decode_json( $response->decoded_content ) || {};
+        # чата не существует: пользователь ещё не запускал этого бота
+        # (например, регистрация через Telegram Login Widget или внешний API)
+        if ( ( $error->{description} // '' ) =~ /chat not found/i ) {
+            $status = 'chat_not_found';
+        }
+    }
+    return unless $status;
+
+    $self->user->set_settings({
+        telegram => {
+            $self->{profile} => {
+                status => $status,
+            },
+        }
+    });
 }
 
 sub sendMessage {


### PR DESCRIPTION
## Проблема

Пользователь может попасть в SHM без запуска бота: регистрация через Telegram Login Widget (`web_auth` с `register_if_not_exists`), привязка телеграма через внешний API. В настройках появляются валидные `chat_id`/`user_id`/`status: member`, но личного чата с ботом на стороне Telegram не существует — чат создаётся только когда пользователь сам нажимает Start.

Каждая отправка такому пользователю падает с `400 Bad Request: chat not found`, задачи в spool повторяются бесконечно, лог заполняется ошибками:

```
ERROR message: {{ {"ok":false,"error_code":400,"description":"Bad Request: chat not found"} }}
	Core::System::Logger::error at /app/lib/Core/Transport/Telegram.pm line 562
	Core::Transport::Telegram::http at /app/lib/Core/Transport/Telegram.pm line 341
	Core::Transport::Telegram::send at LOCAL_PAYMENT line 21
```

## Решение

Расширяет существующий механизм `403 -> kicked` в `http()`:

- **`http()`**: обработка ошибок API вынесена в метод `set_profile_status_by_error()`: `403` -> `kicked` (как раньше), `400` + `chat not found` -> новый статус `chat_not_found`. Одна точка на все вызовы API (send, task_send, bot-команды).
- **`send()`**: профили со статусом `chat_not_found` пропускаются до похода в API — рядом с существующей проверкой `kicked`/`left`.
- **`profile()`**: сброс кэша `user_tg_settings` при смене профиля. Без этого в цикле отправки по профилям статус читался от предыдущего профиля.

## Жизненный цикл статуса

```
member ──(send: chat not found)──> chat_not_found   [дальше skip, лог чистый]
chat_not_found ──(пользователь нажал Start: auth)──> member   [отправка работает]
любой ──(403)──> kicked   [без изменений]
```

Данные лечатся сами: битые записи помечаются при первой отправке, после запуска бота пользователем `auth()` возвращает `member` — как и раньше. Миграция не нужна. Найти всех пользователей без чата можно запросом по `status = 'chat_not_found'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)