### PR TITLE
Запрет смены тарифа на бесплатную услугу для клиента

### DIFF
--- a/app/lib/Core/USObject.pm
+++ b/app/lib/Core/USObject.pm
@@ -903,6 +903,24 @@ sub api_set {
         delete $args{ $_ } unless $allowed_fields{ $_ };
     }
 
+    # Клиент не может назначить бесплатную услугу тарифом на следующий период:
+    # иначе бесплатный период (cost = 0) продлевается бесконечно.
+    # next = -1 (удалить услугу) и next = 0 (сбросить) остаются разрешёнными.
+    if ( defined $args{next} && !get_service('user')->authenticated->is_admin ) {
+        my $next_id = int( $args{next} );
+        if ( $next_id > 0 ) {
+            my $next_service = $self->srv('service', _id => $next_id );
+            unless ( $next_service && $next_service->get_cost && $next_service->get_cost > 0 ) {
+                logger->warning(
+                    sprintf "Denied next=%s (free service) for user service: %s", $args{next}, $self->id
+                );
+                report->status( 403 );
+                report->add_error('The next service must not be free');
+                return undef;
+            }
+        }
+    }
+
     return $self->SUPER::api_set( %args );
 }
 
@@ -921,6 +939,21 @@ sub change {
     unless ( $service ) {
         logger->error("Can't change us to non exists service: $args{service_id}");
         return undef;
+    }
+
+    # Смена тарифа на бесплатный доступна только администратору. Иначе клиент
+    # переключается на бесплатную услугу (в том числе из статуса BLOCK) и
+    # пользуется ей бесконечно: order_only_once тут не помогает, эта проверка
+    # живёт только в Core::Service::price_list, а change её не вызывает.
+    unless ( get_service('user')->authenticated->is_admin ) {
+        unless ( $service->get_cost && $service->get_cost > 0 ) {
+            logger->warning(
+                sprintf "Denied change to free service %s for user service: %s", $args{service_id}, $self->id
+            );
+            report->status( 403 );
+            report->add_error('Switching to a free service is not allowed');
+            return undef;
+        }
     }
 
     $self->set( next => $service->id );


### PR DESCRIPTION
## Проблема

Клиент может сам переключиться на бесплатную услугу и пользоваться ей бесконечно — двумя путями:

1. `POST /user/service/change` с `service_id` бесплатной услуги. `USObject::change` не сверяется с прайс-листом, поэтому флаг `config.order_only_once` обходится: он проверяется только в `Core::Service::price_list` → `was_ever_provided`, а этот путь вызывается лишь при заказе через `/service/order`. Для услуги в статусе `BLOCK` смена срабатывает сразу (`switch_to_next_service`), то есть заблокированная за неуплату услуга реактивируется без оплаты.
2. `api_set` с полем `next`: бесплатная услуга назначается тарифом на следующий период. При истечении услуга продлевается с нулевым списанием и снова получает тот же `next` — период повторяется бесконечно.

Воспроизведение (услуга 21 в примере — «Бесплатный период», `cost = 0`, `allow_to_order = 1`, `config.order_only_once = true`):

```
# клиент уже израсходовал бесплатный период, в прайс-листе услуги 21 больше нет
curl -X POST -H 'session-id: ...' -H 'Content-Type: application/json' \
     -d '{"user_service_id": 11113, "service_id": 21}' \
     https://billing.example.com/shm/v1/user/service/change
# до фикса: 200, услуга снова бесплатная
```

На боевой инсталляции (VPN-биллинг, ~9,5 тыс. пользователей) так утекло 283 бесплатных периода поверх положенных: 238 услуг получили в среднем по два лишних периода, отдельные аккаунты пользовались бесплатно 70–90 дней подряд.

## Решение

В `change` и `api_set` добавлена проверка: услуга с `cost <= 0` для клиента запрещена, ответ `403`.

- администратора проверка не касается — выдать бесплатную услугу вручную по-прежнему можно;
- `next = -1` (удалить услугу) и `next = 0` (сбросить) работают как раньше;
- несуществующий `service_id` тоже отсекается (`get_cost` пустой), поведение fail-closed.

## Проверка

Патч больше месяца ходил в прод-сборке 2.18.2, проверен вживую:

| Сценарий | Результат |
|---|---|
| клиент меняет тариф на бесплатный | `403 Switching to a free service is not allowed` |
| клиент меняет тариф на платный | `200`, смена проходит |
| клиент из статуса `BLOCK` меняет на бесплатный | `403` |
| клиент из статуса `BLOCK` меняет на платный | `200`, реактивация работает |
| админ ставит `next` на бесплатную услугу | проходит |
| заказ бесплатной услуги новым клиентом через `/service/order` | выдаётся как раньше |

`perl -c` против образа проходит. Изменён один файл.